### PR TITLE
app: do not memoize the UUID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,4 @@ sudo: false
 
 cache: bundler
 
-bundler_args: --without development
-
-notifications:
-  irc: "irc.freenode.org#travis"
+bundler_args: --without development --jobs 3 --retry 3 --deployment

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -103,7 +103,7 @@ module Travis
       end
 
       def uuid
-        @uuid ||= Travis.uuid
+        env['HTTP_X_REQUEST_ID'] || Travis.uuid
       end
 
       def event_type

--- a/spec/travis/app_spec.rb
+++ b/spec/travis/app_spec.rb
@@ -40,6 +40,11 @@ describe Travis::Listener::App do
     create
   end
 
+  it "passes the given request ID on" do
+    Travis::Sidekiq::BuildRequest.should_receive(:perform_async).with(QUEUE_PAYLOAD.merge({ "uuid" => "abc-def-ghi" }))
+    create(headers: { "HTTP_X_REQUEST_ID" => "abc-def-ghi" })
+  end
+
   context "with valid_ips provided" do
     before do
       described_class.any_instance.stub(:valid_ips).and_return(['1.2.3.4'])

--- a/spec/travis/app_spec.rb
+++ b/spec/travis/app_spec.rb
@@ -41,7 +41,7 @@ describe Travis::Listener::App do
   end
 
   it "passes the given request ID on" do
-    Travis::Sidekiq::BuildRequest.should_receive(:perform_async).with(QUEUE_PAYLOAD.merge({ "uuid" => "abc-def-ghi" }))
+    Travis::Sidekiq::BuildRequest.should_receive(:perform_async).with(QUEUE_PAYLOAD.merge({ :uuid => "abc-def-ghi" }))
     create(headers: { "HTTP_X_REQUEST_ID" => "abc-def-ghi" })
   end
 


### PR DESCRIPTION
This way, we get a different UUID for each request (using the `X-Request-ID` header that Heroku passes to us).

Right now, every request has the same UUID until listener restarts.