### PR TITLE
Bumped travis-config to the latest version for some HA bug fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       tilt (>= 1.3, < 3)
     thor (0.19.1)
     tilt (2.0.1)
-    travis-config (1.0.3)
+    travis-config (1.0.12)
       hashr (~> 2.0.0)
     unicorn (4.6.3)
       kgio (~> 2.6)
@@ -119,4 +119,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.12.5


### PR DESCRIPTION
Getting this in master as I want to land it in the `te-dev` branch (soon to be `enterprise-2.0`) via a backport. 

Have a customer testing out the High Availability in Enterprise and came across some configurations that would break Travis. Fortunately these things were fixed in `travis-config` 1.0.8 (dealing with the ampq protocol). Now we just need to update to a more recent version of `travis-config` in all of our projects that are involved in building Enterprise. 

