### PR TITLE
Update gems with reported security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'multi_json'
 
 gem 'sentry-raven'
 
-gem 'activesupport',   '~> 3.2.13'
+gem 'activesupport',   '~> 4.1.11'
 
 gem 'metriks'
 gem 'metriks-librato_metrics'

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'metriks-librato_metrics'
 gem 'backports',       '2.4.0'
 
 # structures
-gem 'yajl-ruby',       '~> 1.1.0'
+gem 'yajl-ruby',       '~> 1.3.1'
 
 # heroku
 gem 'unicorn',         '~> 4.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    yajl-ruby (1.1.0)
+    yajl-ruby (1.3.1)
 
 PLATFORMS
   ruby
@@ -112,7 +112,7 @@ DEPENDENCIES
   travis-support!
   unicorn (~> 4.6.2)
   webmock
-  yajl-ruby (~> 1.1.0)
+  yajl-ruby (~> 1.3.1)
 
 RUBY VERSION
    ruby 2.3.5p376

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,12 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (4.1.16)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     atomic (1.1.99)
@@ -28,7 +31,9 @@ GEM
     hashdiff (0.3.4)
     hashr (2.0.1)
     hitimes (1.2.5)
-    i18n (0.8.4)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    json (1.8.6)
     kgio (2.11.0)
     metriks (0.9.9.8)
       atomic (~> 1.0)
@@ -36,6 +41,7 @@ GEM
       hitimes (~> 1.1)
     metriks-librato_metrics (1.0.6)
       metriks (>= 0.9.9.6)
+    minitest (5.11.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     public_suffix (2.0.5)
@@ -69,9 +75,12 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     thor (0.19.4)
+    thread_safe (0.3.6)
     tilt (2.0.7)
     travis-config (1.0.13)
       hashr (~> 2.0.0)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
     unicorn (4.6.3)
       kgio (~> 2.6)
       rack
@@ -86,7 +95,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 3.2.13)
+  activesupport (~> 4.1.11)
   backports (= 2.4.0)
   foreman (~> 0.41.0)
   metriks
@@ -109,4 +118,4 @@ RUBY VERSION
    ruby 2.3.5p376
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
The GitHub vulnerability scanner reported 2 gems with CVEs (one `moderate risk`, one `severe risk`) This updates both gems to earliest-known-good versions.

Tests are 💚 locally, and while ActiveSupport jumps from 3.x to 4.x, our use of it does not appear impacted.