### PR TITLE
Set queue name for events destined for sync

### DIFF
--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -95,7 +95,7 @@ module Travis
 
       def sync_event
         log_event(event_details, uuid: uuid, delivery_guid: delivery_guid, type: event_type)
-        Travis::Sidekiq::GithubSync.push(data)
+        Travis::Sidekiq::GithubSync.push(Travis.config.sync.queue, data)
       end
 
       def handle_event?

--- a/spec/travis/events_spec.rb
+++ b/spec/travis/events_spec.rb
@@ -25,7 +25,9 @@ describe Travis::Listener::App do
   end
 
   shared_examples_for 'queues gh sync event' do |&block|
-    it { expect(gh_sync_queue).to have_received(:push).with(hash_including(type: event)) }
+    it { expect(gh_sync_queue)
+      .to have_received(:push)
+      .with('sync.gh_apps', hash_including(type: event)) }
   end
 
   describe 'a push event' do


### PR DESCRIPTION
I noticed we weren't specifying a queue for the events we intend for Sync. 