### PR TITLE
All events from an App are json payloads

### DIFF
--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -235,7 +235,7 @@ module Travis
       end
 
       def decoded_payload
-        @decoded_payload ||= MultiJson.load(payload)
+        @decoded_payload ||= (payload ? MultiJson.load(payload) : nil)
       end
     end
   end

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -209,13 +209,17 @@ module Travis
       end
 
       def payload
-        if params[:payload]
+        if !params[:payload].blank?
           params[:payload]
-        elsif @_request_body ||= request.body.read
-          @_request_body
+        elsif !request_body.blank?
+          request_body
         else
           nil
         end
+      end
+
+      def request_body
+        @_request_body ||= request.body.read
       end
 
       def slug
@@ -235,7 +239,7 @@ module Travis
       end
 
       def decoded_payload
-        @decoded_payload ||= (payload.nil? ? nil : MultiJson.load(payload))
+        @decoded_payload ||= MultiJson.load(payload)
       end
     end
   end

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -209,7 +209,7 @@ module Travis
       end
 
       def payload
-        unless params[:payload].empty?
+        if params[:payload]
           params[:payload]
         else
           begin

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -32,7 +32,7 @@ module Travis
       end
 
       get '/' do
-        redirect "http://about.travis-ci.org"
+        redirect "http://travis-ci.com"
       end
 
       # Used for new relic uptime monitoring
@@ -209,9 +209,9 @@ module Travis
       end
 
       def payload
-        if github_pr_event?
+        unless params[:payload].empty?
           params[:payload]
-        elsif github_apps_event?
+        else
           begin
             @_parsed_json ||= JSON.parse(request.body.read)
           rescue JSON::ParserError

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -235,7 +235,7 @@ module Travis
       end
 
       def decoded_payload
-        @decoded_payload ||= (payload ? MultiJson.load(payload) : nil)
+        @decoded_payload ||= (payload.nil? ? nil : MultiJson.load(payload))
       end
     end
   end

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -212,11 +212,7 @@ module Travis
         if params[:payload]
           params[:payload]
         else
-          begin
-            @_parsed_json ||= JSON.parse(request.body.read)
-          rescue JSON::ParserError
-            nil
-          end
+          @_request_body ||= request.body.read
         end
       end
 

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -211,8 +211,10 @@ module Travis
       def payload
         if params[:payload]
           params[:payload]
+        elsif @_request_body ||= request.body.read
+          @_request_body
         else
-          @_request_body ||= request.body.read
+          nil
         end
       end
 

--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -205,7 +205,7 @@ module Travis
       end
 
       def delivery_guid
-        env['HTTP_X_GITHUB_GUID']
+        env['HTTP_X_GITHUB_GUID'] || env['HTTP_X_GITHUB_DELIVERY']
       end
 
       def payload

--- a/spec/travis/app_spec.rb
+++ b/spec/travis/app_spec.rb
@@ -13,7 +13,12 @@ describe Travis::Listener::App do
   end
 
   def create(opts = {})
-    params  = { :payload => (opts[:payload] || payload) }
+    params  = {}
+
+    if params_payload = (opts[:payload] || payload)
+      params[:payload] = params_payload
+    end
+
     headers = { 'HTTP_X_GITHUB_EVENT' => 'push', 'HTTP_X_GITHUB_GUID' => 'abc123' }
     headers.merge!(opts.delete(:headers) || {})
 


### PR DESCRIPTION
The previous logic created issues where 422s were returned to GitHub as Push and Pull Request events were json payloads, but we checked the `params[:payload]`, only for it to be nil.