### PR TITLE
Log source payload when encountering an error

### DIFF
--- a/lib/travis/listener/app.rb
+++ b/lib/travis/listener/app.rb
@@ -179,6 +179,7 @@ module Travis
       rescue => e
         error("Error logging payload: #{e.message}")
         error("Payload causing error: #{decoded_payload}")
+        error("Original payload causing error: #{payload}")
         Raven.capture_exception(e)
         {}
       end


### PR DESCRIPTION
A minor but recurring error that pops up in Sentry is a NoMethodError
when attempting to access the `sender` field of the source payload. For
some reason, this field can come up blank, and while I could code a
simple fix to get around this issue, I'd like to examine the incoming
payloads to see if there's something about them that is wacky; sender
seems like a pretty basic should-always-be-there kind of field,
afterall!