### PR TITLE
Put member events into default sync queue

### DIFF
--- a/lib/travis/sidekiq.rb
+++ b/lib/travis/sidekiq.rb
@@ -35,7 +35,7 @@ module Travis
       def self.gh_app_member(data)
         Metriks.meter('listener.event.gh_apps_member').mark
 
-        push('sync.gh_apps', :gh_app_member, data)
+        push('sync', :gh_app_member, data)
       end
 
       def self.client

--- a/spec/travis/events_spec.rb
+++ b/spec/travis/events_spec.rb
@@ -128,6 +128,6 @@ describe Travis::Listener::App do
 
     it { expect(gh_sync_queue)
       .to have_received(:push)
-      .with('sync.gh_apps', :gh_app_member, hash_including(type: event)) }
+      .with('sync', :gh_app_member, hash_including(type: event)) }
   end
 end


### PR DESCRIPTION
Previously we'd created a queue solely for GitHub Apps events, and when
it came time to add member event handling, it seemed natural to put
those into that same queue - they're from GH Apps enabled repos,
afterall.. However, we were doing this for both org and com, and sync
doesn't run workers on org to process the `sync.github_apps` queue, so
these events pile up in the queue. We don't really need to put these
particular events into their own queue, the default `sync` queue will do
just fine.

travis-pro/team-teal#2744