### PR TITLE
Bump Sinatra version 2.0.1 -> 2.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'sidekiq',         '~> 4.0.0'
 gem 'redis-namespace'
 
 gem 'puma'
-gem 'sinatra',         '~> 2.0.0'
+gem 'sinatra',         '~> 2.0.3'
 gem 'rake',            '~> 0.9.2.2'
 
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,13 +45,13 @@ GEM
       metriks (>= 0.9.9.6)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     puma (3.11.4)
     rack (2.0.5)
-    rack-protection (2.0.1)
+    rack-protection (2.0.3)
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -73,10 +73,10 @@ GEM
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       redis (~> 3.2, >= 3.2.1)
-    sinatra (2.0.1)
+    sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.3)
       tilt (~> 2.0)
     thor (0.20.0)
     thread_safe (0.3.6)
@@ -104,7 +104,7 @@ DEPENDENCIES
   rspec (~> 2.9)
   sentry-raven
   sidekiq (~> 4.0.0)
-  sinatra (~> 2.0.0)
+  sinatra (~> 2.0.3)
   travis-config (~> 1.0.0)
   travis-support!
   yajl-ruby (~> 1.4.0)
@@ -113,4 +113,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
:octocat: pestered me just now about a security vulnerability in 2.0.1, so bumping the version here. Looks like minor point releases on Sinatra deps, tests are 🍏 