### PR TITLE
Put pull_request title in redis

### DIFF
--- a/lib/travis/listener/schemas.rb
+++ b/lib/travis/listener/schemas.rb
@@ -37,7 +37,8 @@ module Travis
             "user" => {
               "login" => nil
             }
-          }
+          },
+          "title" => nil
         },
         "repository" => {
           "id" => nil,
@@ -123,6 +124,7 @@ module Travis
             head:       payload['pull_request']['head']['sha'][0..6],
             ref:        payload['pull_request']['head']['ref'],
             user:       payload['pull_request']['head']['user']['login'],
+            title:      payload['pull_request']['title'],
             sender:     payload['sender']['login']
           }
         when 'push'


### PR DESCRIPTION
Hi there,
in order to provide pull_request title in job as env variable it needs to be read from github payload first.

See https://github.com/travis-ci/travis-ci/issues/9288 for more information about this feature request.