### PR TITLE
ignore the new tag created check suite event

### DIFF
--- a/lib/travis/listener/schemas.rb
+++ b/lib/travis/listener/schemas.rb
@@ -67,6 +67,26 @@ module Travis
         }
       }
 
+      CHECK_SUITE = {
+        "action" => nil,
+        "check_suite" => {
+          "ref_type" => nil
+        },
+        "repository" => {
+          "id" => nil,
+          "name" => nil,
+          "full_name" => nil,
+          "owner" => {
+            "login" => nil
+          },
+          "private" => nil
+        },
+        "sender" => {
+          "id" => nil,
+          "login" => nil
+        }
+      }
+
       REPOSITORY = {
         "action" => nil,
         "repository" => {
@@ -133,7 +153,14 @@ module Travis
             commits:   (payload["commits"] || []).map {|c| c['id'][0..6]}.join(","),
             sender:     payload['sender']['login']
           }
-        when 'create', 'delete', 'repository', 'check_run', 'check_suite'
+        when 'check_suite'
+          {
+            action:     payload['action'],
+            ref_type:   payload['check_suite']['ref_type'],
+            repository: payload["repository"]["full_name"],
+            sender:     payload['sender']['login']
+          }
+        when 'create', 'delete', 'repository', 'check_run'
           {
             action:     payload['action'],
             repository: payload["repository"]["full_name"],

--- a/spec/payloads/rerequested_check_suite_tag_ref_type.json
+++ b/spec/payloads/rerequested_check_suite_tag_ref_type.json
@@ -1,46 +1,29 @@
 {
-    "action": "rerequested",
+    "action": "requested",
     "check_suite": {
-      "id": 55,
-      "ref_type": "branch",
-      "branch": "master",
-      "sha": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
+      "id": 5,
+      "ref_type": "tag",
+      "head_branch": "master",
+      "head_sha": "d6fde92930d4715a2b49857d24b940956b26d2d3",
       "status": "completed",
       "conclusion": "neutral",
-      "url": "https://api.github.com/repos/github/hello-world/check-suites/55",
-      "before": "e6a8776dca057e538c800aaa7ff8fe2a08f35ef6",
-      "after": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
-      "pull_requests": [{
-        "url": "https://api.github.com/repos/github/hello-world/pulls/1",
-        "id": 1934,
-        "head": {
-          "ref": "say-hello",
-          "sha": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
-          "repo": {
-            "id": 526,
-            "url": "https://api.github.com/repos/github/hello-world",
-            "name": "hello-world"
-          }
-        },
-        "base": {
-          "ref": "master",
-          "sha": "e7fdf7640066d71ad16a86fbcbb9c6a10a18af4f",
-          "repo": {
-            "id": 526,
-            "url": "https://api.github.com/repos/github/hello-world",
-            "name": "hello-world"
-          }
-        }
-      }],
+      "url": "https://api.github.com/repos/github/hello-world/check-suites/5",
+      "before": "146e867f55c26428e5f9fade55a9bbf5e95a7912",
+      "after": "d6fde92930d4715a2b49857d24b940956b26d2d3",
+      "pull_requests": [
+  
+      ],
       "app": {
-        "id": 3,
+        "id": 2,
+        "node_id": "MDExOkludGVncmF0aW9uMQ==",
         "owner": {
           "login": "github",
           "id": 340,
-          "avatar_url": "http://alambic.github.localhost/avatars/u/340?",
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+          "avatar_url": "http://alambic.github.com/avatars/u/340?",
           "gravatar_id": "",
           "url": "https://api.github.com/users/github",
-          "html_url": "http://github.localhost/github",
+          "html_url": "http://github.com/github",
           "followers_url": "https://api.github.com/users/github/followers",
           "following_url": "https://api.github.com/users/github/following{/other_user}",
           "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
@@ -56,19 +39,19 @@
         "name": "Super Duper",
         "description": null,
         "external_url": "http://super-duper.example.com",
-        "html_url": "http://github.localhost/apps/super-duper",
-        "created_at": "2018-04-05 17:13:50 UTC",
-        "updated_at": "2018-04-05 17:13:50 UTC"
+        "html_url": "http://github.com/apps/super-duper",
+        "created_at": "2018-04-25 20:42:10",
+        "updated_at": "2018-04-25 20:42:10"
       },
-      "created_at": "2018-04-06T18:32:21Z",
-      "updated_at": "2018-04-06T18:32:21Z",
-      "unique_check_runs_count": 1,
-      "check_runs_url": "https://api.github.com/repos/github/hello-world/check-suites/55/check-runs",
+      "created_at": "2018-05-04T01:14:52Z",
+      "updated_at": "2018-05-04T01:14:52Z",
+      "latest_check_runs_count": 1,
+      "check_runs_url": "https://api.github.com/repos/github/hello-world/check-suites/5/check-runs",
       "head_commit": {
-        "id": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
-        "tree_id": "f2eeeb75e48a014b6b379b0f47b612a93f85dd44",
+        "id": "d6fde92930d4715a2b49857d24b940956b26d2d3",
+        "tree_id": "41a846c7d878d279f11355e23b348e1bb63b89a8",
         "message": "Say hello (again) to everybody",
-        "timestamp": "2018-04-06T18:32:05Z",
+        "timestamp": "2018-05-04T01:14:46Z",
         "author": {
           "name": "octocat",
           "email": "octocat@github.com"
@@ -81,15 +64,17 @@
     },
     "repository": {
       "id": 526,
+      "node_id": "MDEwOlJlcG9zaXRvcnkxMzU0OTMyMzM=",
       "name": "hello-world",
       "full_name": "github/hello-world",
       "owner": {
         "login": "github",
         "id": 340,
-        "avatar_url": "http://alambic.github.localhost/avatars/u/340?",
+        "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+        "avatar_url": "http://alambic.github.com/avatars/u/340?",
         "gravatar_id": "",
         "url": "https://api.github.com/users/github",
-        "html_url": "http://github.localhost/github",
+        "html_url": "http://github.com/github",
         "followers_url": "https://api.github.com/users/github/followers",
         "following_url": "https://api.github.com/users/github/following{/other_user}",
         "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
@@ -103,7 +88,7 @@
         "site_admin": false
       },
       "private": false,
-      "html_url": "http://github.localhost/github/hello-world",
+      "html_url": "http://github.com/github/hello-world",
       "description": null,
       "fork": false,
       "url": "https://api.github.com/repos/github/hello-world",
@@ -143,13 +128,13 @@
       "labels_url": "https://api.github.com/repos/github/hello-world/labels{/name}",
       "releases_url": "https://api.github.com/repos/github/hello-world/releases{/id}",
       "deployments_url": "https://api.github.com/repos/github/hello-world/deployments",
-      "created_at": "2018-04-05T17:13:50Z",
-      "updated_at": "2018-04-06T17:57:34Z",
-      "pushed_at": "2018-04-06T18:32:09Z",
-      "git_url": "git://github.localhost/github/hello-world.git",
+      "created_at": "2018-04-25T20:42:10Z",
+      "updated_at": "2018-04-25T20:43:34Z",
+      "pushed_at": "2018-05-04T01:14:47Z",
+      "git_url": "git://github.com/github/hello-world.git",
       "ssh_url": "ssh://git@localhost:3035/github/hello-world.git",
-      "clone_url": "http://github.localhost/github/hello-world.git",
-      "svn_url": "http://github.localhost/github/hello-world",
+      "clone_url": "http://github.com/github/hello-world.git",
+      "svn_url": "http://github.com/github/hello-world",
       "homepage": null,
       "size": 0,
       "stargazers_count": 0,
@@ -163,16 +148,17 @@
       "forks_count": 0,
       "mirror_url": null,
       "archived": false,
-      "open_issues_count": 1,
+      "open_issues_count": 3,
       "license": null,
       "forks": 0,
-      "open_issues": 1,
+      "open_issues": 3,
       "watchers": 0,
       "default_branch": "master"
     },
     "organization": {
       "login": "github",
       "id": 340,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
       "url": "https://api.github.com/orgs/github",
       "repos_url": "https://api.github.com/orgs/github/repos",
       "events_url": "https://api.github.com/orgs/github/events",
@@ -180,16 +166,17 @@
       "issues_url": "https://api.github.com/orgs/github/issues",
       "members_url": "https://api.github.com/orgs/github/members{/member}",
       "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-      "avatar_url": "http://alambic.github.localhost/avatars/u/340?",
+      "avatar_url": "http://alambic.github.com/avatars/u/340?",
       "description": "How people build software."
     },
     "sender": {
       "login": "octocat",
-      "id": 5347,
-      "avatar_url": "http://alambic.github.localhost/avatars/u/5347?",
+      "id": 5346,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "avatar_url": "http://alambic.github.com/avatars/u/5346?",
       "gravatar_id": "",
       "url": "https://api.github.com/users/octocat",
-      "html_url": "http://github.localhost/octocat",
+      "html_url": "http://github.com/octocat",
       "followers_url": "https://api.github.com/users/octocat/followers",
       "following_url": "https://api.github.com/users/octocat/following{/other_user}",
       "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
@@ -203,6 +190,7 @@
       "site_admin": false
     },
     "installation": {
-      "id": 2
+      "id": 1
     }
   }
+  

--- a/spec/travis/events_spec.rb
+++ b/spec/travis/events_spec.rb
@@ -30,6 +30,10 @@ describe Travis::Listener::App do
     it { expect(gatekeeper_queue).to have_received(:push).with('build_requests', hash_including(type: event)) }
   end
 
+  shared_examples_for 'does not queue gatekeeper event' do |&block|
+    it { expect(gatekeeper_queue).not_to have_received(:push).with('build_requests', hash_including(type: event)) }
+  end
+
   describe 'a push event' do
     let(:type)  { 'push' }
     let(:event) { 'push' }
@@ -97,11 +101,18 @@ describe Travis::Listener::App do
     include_examples 'queues gatekeeper event'
   end
 
-  describe 'a create_suite event' do
+  describe 'a create_suite event : ref_type branch' do
     let(:type)  { 'rerequested_check_suite' }
     let(:event) { 'check_suite' }
 
     include_examples 'queues gatekeeper event'
+  end
+
+  describe 'a create_suite tag : ref_type event' do
+    let(:type)  { 'rerequested_check_suite_tag_ref_type' }
+    let(:event) { 'check_suite' }
+
+    include_examples 'does not queue gatekeeper event'
   end
 
   describe 'an installation event' do


### PR DESCRIPTION
GitHub is adding a about to fire a new event when tags are created, except it isn't really a new event, but firing another form of the check suite rerequested event.

We are going to ignore this event as we already process tag created events in a different way.

This PR filters out the check suite events with a `ref_type` of tag.